### PR TITLE
Add run provenance to local execution

### DIFF
--- a/src/robovast/execution/execution_utils/cli.py
+++ b/src/robovast/execution/execution_utils/cli.py
@@ -117,6 +117,16 @@ def run(config, runs, output, shell, no_gui, network_host, image):
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
+@local.command()
+@click.argument("run_path", type=click.Path(exists=True))
+@click.argument("dataset_iri", type=click.STRING)
+@click.option('--scenarios', default="scenarios")
+@click.option('--environments', default="environments")
+@click.option('--runs', default="runs")
+@click.option('--agents', default="agents")
+def prov(run_path, dataset_iri, **kwargs):
+    from robovast.prov.generate_prov_graph import get_run_prov
+    get_run_prov(run_path, dataset_iri, **kwargs)
 
 @local.command()
 @click.argument('output-dir', type=click.Path())

--- a/src/robovast/prov/generate_prov_graph.py
+++ b/src/robovast/prov/generate_prov_graph.py
@@ -153,7 +153,7 @@ def save_scenario_prov(graph, config, output_dir):
         json.dump(doc, f, indent=2)
 
 
-def get_run_prov(run_output_dir):
+def get_run_prov(run_output_dir, dataset_iri, **kwargs):
     # Get run information from run.yaml
     run_yaml_path = os.path.join(run_output_dir, "run.yaml")
     run_data = get_run_data(run_yaml_path)
@@ -166,10 +166,13 @@ def get_run_prov(run_output_dir):
     run_data["ROSBAG_DIR"] = rosbag_file
     prov_data = _gen_jsonld_prov(run_output_dir, run_data)
 
+    doc = _get_jsonld_context(dataset_iri, **kwargs)
+    doc["@graph"] = prov_data
+
     # Write JSON file
     output_path = os.path.join(run_output_dir, "run.prov.json")
     with open(output_path, "w") as f:
-        json.dump(prov_data, f, indent=4)
+        json.dump(doc, f, indent=4)
 
 
 def main():


### PR DESCRIPTION
This expects a `run.yaml` with the following contents:

```yaml
RUN_ID: hospital5m0o-1-1-run-0-2025-11-13-092530 # Make more descriptive
RUN_NUM: 0
START_DATE: 2025-11-13T092530
END_DATE: 2025-11-13T093023 
SCENARIO_ID: hospital5m0o-1-1
SCENARIO_CONFIG: nav_to_pose/configs/hospital5m0o-1-1-000.config
LOG_DIR: logs
ROSBAG_DIR: rosbag2
ROBOT_ID: turtlebot-4
ROBOT_CONFIG: diff-config/
```

The `.vast` file should include the following params:

```yaml
provenance:
  dataset_iri: https://cpt-test-lab.github.io/robovast-datasets/2026-robovast-navigation/
  scenarios: scenarios # optional 
  runs: runs # optional
  agents: robots # optional
  environments: environments # optional
```