### PR TITLE
Add robovast_manipulation  and manipulation variation plugin

### DIFF
--- a/configs/examples/manipulation/manipulation.vast
+++ b/configs/examples/manipulation/manipulation.vast
@@ -1,0 +1,86 @@
+version: 1
+metadata:
+  name: manipulation
+  dataset_iri: "https://example.org/campaigns/manipulation/"
+
+configuration:
+  - name: rrtconnect
+    parameters:
+      - planner_id: "RRTConnect"
+    variations:
+      - ParameterVariationList:
+          name: arm_joint_goal
+          values:
+            - [1.57, 0.0, 0.0]
+            - [0.5, 0.5, 0.0]
+            - [-1.0, 0.3, 0.2]
+      - ParameterVariationList:
+          name:
+            - velocity_scaling_requested
+            - acceleration_scaling_requested
+          values:
+            - [0.1, 0.1]
+            - [0.5, 0.5]
+            - [1.0, 1.0]
+      - ParameterVariationList:
+          name: gripper_joint_goal
+          values:
+            - [-0.7]
+      - ManipulationVariation: {}
+
+  - name: ptp
+    parameters:
+      - planner_id: "PTP"
+    variations:
+      - ParameterVariationList:
+          name: arm_joint_goal
+          values:
+            - [1.57, 0.0, 0.0]
+            - [0.5, 0.5, 0.0]
+            - [-1.0, 0.3, 0.2]
+      - ParameterVariationList:
+          name:
+            - velocity_scaling_requested
+            - acceleration_scaling_requested
+          values:
+            - [0.1, 0.1]
+            - [0.5, 0.5]
+            - [1.0, 1.0]
+      - ParameterVariationList:
+          name: gripper_joint_goal
+          values:
+            - [-0.7]
+      - ManipulationVariation: {}
+
+  - name: kpiece1
+    parameters:
+      - planner_id: "KPIECE1"
+    variations:
+      - ParameterVariationList:
+          name: arm_joint_goal
+          values:
+            - [1.57, 0.0, 0.0]
+            - [0.5, 0.5, 0.0]
+            - [-1.0, 0.3, 0.2]
+      - ParameterVariationList:
+          name:
+            - velocity_scaling_requested
+            - acceleration_scaling_requested
+          values:
+            - [0.1, 0.1]
+            - [0.5, 0.5]
+            - [1.0, 1.0]
+      - ParameterVariationList:
+          name: gripper_joint_goal
+          values:
+            - [-0.7]
+      - ManipulationVariation: {}
+
+execution:
+  image: "local"
+  runs: 5
+  scenario_file: scenario.osc
+  run_files:
+    - "launch/*.py"
+    - "config/*.yaml"
+

--- a/configs/examples/manipulation/manipulation.vast
+++ b/configs/examples/manipulation/manipulation.vast
@@ -4,9 +4,7 @@ metadata:
   dataset_iri: "https://example.org/campaigns/manipulation/"
 
 configuration:
-  - name: rrtconnect
-    parameters:
-      - planner_id: "RRTConnect"
+  - name: manipulation
     variations:
       - ParameterVariationList:
           name: arm_joint_goal
@@ -26,55 +24,11 @@ configuration:
           name: gripper_joint_goal
           values:
             - [-0.7]
-      - ManipulationVariation: {}
-
-  - name: ptp
-    parameters:
-      - planner_id: "PTP"
-    variations:
-      - ParameterVariationList:
-          name: arm_joint_goal
-          values:
-            - [1.57, 0.0, 0.0]
-            - [0.5, 0.5, 0.0]
-            - [-1.0, 0.3, 0.2]
-      - ParameterVariationList:
-          name:
-            - velocity_scaling_requested
-            - acceleration_scaling_requested
-          values:
-            - [0.1, 0.1]
-            - [0.5, 0.5]
-            - [1.0, 1.0]
-      - ParameterVariationList:
-          name: gripper_joint_goal
-          values:
-            - [-0.7]
-      - ManipulationVariation: {}
-
-  - name: kpiece1
-    parameters:
-      - planner_id: "KPIECE1"
-    variations:
-      - ParameterVariationList:
-          name: arm_joint_goal
-          values:
-            - [1.57, 0.0, 0.0]
-            - [0.5, 0.5, 0.0]
-            - [-1.0, 0.3, 0.2]
-      - ParameterVariationList:
-          name:
-            - velocity_scaling_requested
-            - acceleration_scaling_requested
-          values:
-            - [0.1, 0.1]
-            - [0.5, 0.5]
-            - [1.0, 1.0]
-      - ParameterVariationList:
-          name: gripper_joint_goal
-          values:
-            - [-0.7]
-      - ManipulationVariation: {}
+      - ManipulationVariation:
+          planners:
+            - "RRTConnect"
+            - "PTP"
+            - "KPIECE1"
 
 execution:
   image: "local"
@@ -84,3 +38,6 @@ execution:
     - "launch/*.py"
     - "config/*.yaml"
 
+results_processing:
+  postprocessing:
+    - manipulation_process_results: {}

--- a/configs/examples/manipulation/scenario.osc
+++ b/configs/examples/manipulation/scenario.osc
@@ -1,0 +1,10 @@
+import osc.helpers
+
+scenario manipulation:
+    planner_id: string
+    arm_joint_goal: list of float
+    gripper_joint_goal: list of float
+    velocity_scaling_requested: float
+    acceleration_scaling_requested: float
+    do serial:
+        emit end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ webdav = "robovast.execution.cluster_execution.share_providers.webdav:WebDavShar
 [tool.poetry.plugins."robovast.postprocessing_commands"]
 command = "robovast.results_processing.postprocessing_plugins:Command"
 rosbags_process = "robovast.results_processing.postprocessing_plugins:RosbagsProcess"
+manipulation_process_results = "robovast_manipulation.manipulation_postprocessing:ManipulationProcessResults"
 
 [tool.poetry.plugins."robovast.publication_plugins"]
 zip = "robovast.results_processing.publication_plugins.zip:Zip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ webdav = "robovast.execution.cluster_execution.share_providers.webdav:WebDavShar
 "ParameterVariationDistributionUniform" = "robovast.common.variation.parameter_variation:ParameterVariationDistributionUniform"
 "ParameterVariationDistributionGaussian" = "robovast.common.variation.parameter_variation:ParameterVariationDistributionGaussian"
 "OneOfVariation" = "robovast.common.variation.one_of_variation:OneOfVariation"
+"ManipulationVariation" = "robovast_manipulation.manipulation_variation:ManipulationVariation"
 
 [tool.poetry.plugins."robovast.postprocessing_commands"]
 command = "robovast.results_processing.postprocessing_plugins:Command"

--- a/src/robovast/common/variation/base_variation.py
+++ b/src/robovast/common/variation/base_variation.py
@@ -210,6 +210,7 @@ class Variation():
         config_namespace,
         gen_activity_id: str,
         vast_id: str,
+        campaign_dir=None,
     ) -> Optional["ProvContribution"]:
         """Return domain-specific PROV-O graph contributions.
 

--- a/src/robovast/results_processing/fair_metadata.py
+++ b/src/robovast/results_processing/fair_metadata.py
@@ -87,25 +87,37 @@ def load_graph(file_path: str) -> "rdflib.Graph":
     return g
 
 
-def _build_iri_context(dataset_iri: str) -> dict:
-    """Build the JSON-LD IRI context with the given dataset IRI."""
+def _build_iri_context(dataset_iri: str, extra_namespaces: dict = None) -> dict:
+    """Build the JSON-LD IRI context with the given dataset IRI.
+
+    Args:
+        dataset_iri: The dataset IRI for the ``dataset`` prefix.
+        extra_namespaces: Optional prefix→IRI dict contributed by variation
+            plugins via their ``prov_namespaces()`` classmethod.  These are
+            merged into the local context block so domain-specific IRIs
+            compact correctly without hardcoding them here.
+    """
+    local_block = {
+        "agn": "https://purl.org/secorolab/metamodels/agent#",
+        "smm": "https://purl.org/secorolab/metamodels/scenarios/osc/",
+        "env": "https://purl.org/secorolab/metamodels/environment#",
+        "robovast": "https://purl.org/robovast/metamodels/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "prov": "http://www.w3.org/ns/prov#",
+        "dcterms": "http://purl.org/dc/terms/",
+        "qudt": "http://qudt.org/schema/qudt/",
+        "unit": "http://qudt.org/vocab/unit/",
+        "dataset": dataset_iri,
+        "variations": {"@id": "robovast:variations", "@type": "@id"}
+    }
+    if extra_namespaces:
+        local_block.update(extra_namespaces)
     return {
         _CONTEXT: [
             "https://secorolab.github.io/metamodels/prov.json",
             "https://secorolab.github.io/metamodels/metadata.json",
             "https://raw.githubusercontent.com/cps-test-lab/metamodels/refs/heads/main/robovast.json",
-            {
-                "agn": "https://purl.org/secorolab/metamodels/agent#",
-                "smm": "https://purl.org/secorolab/metamodels/scenarios/osc/",
-                "env": "https://purl.org/secorolab/metamodels/environment#",
-                "robovast": "https://purl.org/robovast/metamodels/",
-                "xsd": "http://www.w3.org/2001/XMLSchema#",
-                "prov": "http://www.w3.org/ns/prov#",
-                "dcterms": "http://purl.org/dc/terms/",
-                "qudt": "http://qudt.org/schema/qudt/",
-                "unit": "http://qudt.org/vocab/unit/",
-                "dataset": dataset_iri,
-            }
+            local_block,
         ]
     }
 
@@ -408,10 +420,15 @@ def generate_prov_metadata(
 
     dataset_ns = Namespace(dataset_iri)
     campaign_ns = Namespace(f"{dataset_iri}{campaign}")
-    iri_context = _build_iri_context(dataset_iri)
 
-    # Load variation plugin classes for PROV hooks
+    # Load variation plugin classes for PROV hooks.
+    # Collect any namespace prefixes they declare so the context stays generic.
     variation_classes = load_variation_classes()
+    plugin_namespaces: dict = {}
+    for cls in variation_classes.values():
+        if hasattr(cls, "prov_namespaces"):
+            plugin_namespaces.update(cls.prov_namespaces())
+    iri_context = _build_iri_context(dataset_iri, extra_namespaces=plugin_namespaces)
 
     graph = []
 
@@ -523,7 +540,7 @@ def generate_prov_metadata(
         }
         graph.append({
             _ID: campaign_ns[config_path+"_config/scenario.config"],
-            _TYPE: [PROV["Location"]]
+            _TYPE: [PROV["Entity"]]
         })
 
         # Collect domain-specific PROV contributions from variation plugins
@@ -543,7 +560,8 @@ def generate_prov_metadata(
                     campaign_namespace=campaign_ns,
                     config_namespace=config_ns,
                     gen_activity_id=gen_activity[_ID],
-                    vast_id=vast_config[_ID]
+                    vast_id=vast_config[_ID],
+                    campaign_dir=campaign_dir,
                 )
             except Exception as e:
                 logger.warning(

--- a/src/robovast_manipulation/__init__.py
+++ b/src/robovast_manipulation/__init__.py
@@ -1,0 +1,13 @@
+"""robovast_manipulation — manipulation-domain PROV-O support for robovast.
+
+Provides the canonical namespace URI/prefix and the ManipulationVariation
+plugin that contributes manipulation-specific PROV-O nodes to campaign
+provenance graphs.
+"""
+
+MANIPULATION_NS_URI = "https://purl.org/robovast/manipulation/"
+MANIPULATION_NS_PREFIX = "manipulation"
+
+from robovast_manipulation.manipulation_variation import ManipulationVariation  # noqa: E402
+
+__all__ = ["MANIPULATION_NS_URI", "MANIPULATION_NS_PREFIX", "ManipulationVariation"]

--- a/src/robovast_manipulation/manipulation_postprocessing.py
+++ b/src/robovast_manipulation/manipulation_postprocessing.py
@@ -1,0 +1,61 @@
+"""Postprocessing plugin for manipulation campaigns.
+
+Reads result.json from each run directory and writes a summary CSV.
+"""
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+from robovast.results_processing.postprocessing_plugins import BasePostprocessingPlugin
+
+logger = logging.getLogger(__name__)
+
+_RESULT_FIELDS = [
+    "result_code",
+    "planning_time_sec",
+    "execution_time_sec",
+    "joint_space_error",
+    "final_joint_state",
+]
+
+
+class ManipulationProcessResults(BasePostprocessingPlugin):
+    """Read result.json files from all runs and write manipulation_results.csv."""
+
+    def __call__(
+        self,
+        results_dir: str,
+        config_dir: str,
+        provenance_file: Optional[str] = None,
+        **kwargs,
+    ) -> Tuple[bool, str]:
+        results_path = Path(results_dir)
+        rows = []
+
+        for result_json in sorted(results_path.glob("*/*/result.json")):
+            run_dir = result_json.parent
+            config_name = run_dir.parent.name
+            run_number = run_dir.name
+            try:
+                with open(result_json, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                row = {"config": config_name, "run": run_number}
+                for field in _RESULT_FIELDS:
+                    row[field] = data.get(field)
+                rows.append(row)
+            except Exception as exc:
+                logger.warning("Could not read %s: %s", result_json, exc)
+
+        if not rows:
+            return True, "No result.json files found — nothing to process"
+
+        out_csv = results_path / "manipulation_results.csv"
+        with open(out_csv, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=["config", "run"] + _RESULT_FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+
+        return True, f"Wrote {len(rows)} rows to {out_csv}"

--- a/src/robovast_manipulation/manipulation_variation.py
+++ b/src/robovast_manipulation/manipulation_variation.py
@@ -1,0 +1,121 @@
+"""ManipulationVariation — robovast variation plugin for manipulation experiments.
+
+Contributes manipulation-specific PROV-O nodes to the campaign provenance
+graph: per-config scenario properties (planner, velocity/acceleration scaling,
+joint goal) and per-run ManipulationExecution activity nodes with result
+metrics read from each run's result.json.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from rdflib import PROV, Namespace
+
+from robovast.common.variation.base_variation import ProvContribution, Variation
+from robovast_manipulation import MANIPULATION_NS_PREFIX, MANIPULATION_NS_URI
+
+logger = logging.getLogger(__name__)
+
+MANIPULATION = Namespace(MANIPULATION_NS_URI)
+
+
+class ManipulationVariation(Variation):
+    """Variation plugin that contributes manipulation-specific PROV-O nodes.
+
+    Does not generate new configurations (``variation()`` is a pass-through).
+    Its sole purpose is to hook into the PROV generation pipeline via
+    ``prov_namespaces()`` and ``collect_prov_metadata()``.
+    """
+
+    def variation(self, in_configs):
+        """Pass configs through unchanged — this variation adds no new configs."""
+        return in_configs
+
+    @classmethod
+    def prov_namespaces(cls) -> dict:
+        """Declare the manipulation namespace prefix for the JSON-LD context."""
+        return {MANIPULATION_NS_PREFIX: MANIPULATION_NS_URI}
+
+    @classmethod
+    def collect_prov_metadata(
+        cls,
+        config_entry: dict,
+        campaign_namespace,
+        config_namespace,
+        gen_activity_id: str,
+        vast_id: str,
+        campaign_dir: Optional[Path] = None,
+    ) -> Optional[ProvContribution]:
+        config = config_entry.get("config", {})
+
+        # --- Config-level properties (merged onto ConcreteScenario node) ---
+        scenario_properties: dict = {}
+        if config.get("planner_id") is not None:
+            scenario_properties[str(MANIPULATION["plannerId"])] = config["planner_id"]
+        if config.get("velocity_scaling_requested") is not None:
+            scenario_properties[str(MANIPULATION["velocityScaling"])] = config[
+                "velocity_scaling_requested"
+            ]
+        if config.get("acceleration_scaling_requested") is not None:
+            scenario_properties[str(MANIPULATION["accelerationScaling"])] = config[
+                "acceleration_scaling_requested"
+            ]
+        if config.get("arm_joint_goal") is not None:
+            scenario_properties[str(MANIPULATION["armJointGoal"])] = json.dumps(
+                config["arm_joint_goal"]
+            )
+
+        # --- Run-level nodes (one ManipulationExecution Activity per run) ---
+        graph_nodes = []
+
+        for run_entry in config_entry.get("test_results", []):
+            run_dir_rel = run_entry["dir"]  # e.g. "rrtconnect-1-1-1/1"
+            run_number = run_dir_rel.rsplit("/", 1)[-1]  # "1"
+
+            result: dict = {}
+            if campaign_dir is not None:
+                result_path = Path(campaign_dir) / run_dir_rel / "result.json"
+                try:
+                    with open(result_path, encoding="utf-8") as fh:
+                        result = json.load(fh)
+                except Exception as exc:
+                    logger.warning(
+                        "ManipulationVariation: could not read %s: %s",
+                        result_path,
+                        exc,
+                    )
+
+            test_exec_iri = str(campaign_namespace[run_dir_rel])
+            manip_exec_iri = str(
+                config_namespace[f"{run_number}/manipulation_execution"]
+            )
+
+            node: dict = {
+                "@id": manip_exec_iri,
+                "@type": [str(PROV["Activity"]), str(MANIPULATION["ManipulationExecution"])],
+                str(PROV["wasInformedBy"]): test_exec_iri,
+            }
+
+            for src_key, tgt_key in (
+                ("result_code",        str(MANIPULATION["resultCode"])),
+                ("planning_time_sec",  str(MANIPULATION["planningTimeSec"])),
+                ("execution_time_sec", str(MANIPULATION["executionTimeSec"])),
+                ("joint_space_error",  str(MANIPULATION["jointSpaceError"])),
+                ("final_joint_state",  str(MANIPULATION["finalJointState"])),
+            ):
+                val = result.get(src_key)
+                if val is not None:
+                    node[tgt_key] = val
+
+            graph_nodes.append(node)
+
+        if not scenario_properties and not graph_nodes:
+            return None
+
+        return ProvContribution(
+            graph_nodes=graph_nodes,
+            scenario_properties=scenario_properties,
+            run_used_iris=[],
+        )

--- a/src/robovast_manipulation/manipulation_variation.py
+++ b/src/robovast_manipulation/manipulation_variation.py
@@ -1,41 +1,48 @@
 """ManipulationVariation — robovast variation plugin for manipulation experiments.
 
-Contributes manipulation-specific PROV-O nodes to the campaign provenance
-graph: per-config scenario properties (planner, velocity/acceleration scaling,
-joint goal) and per-run ManipulationExecution activity nodes with result
-metrics read from each run's result.json.
+Expands input configurations by planner ID and contributes manipulation-specific
+scenario properties (planner, velocity/acceleration scaling, joint goals) to the
+PROV-O provenance graph.
+Run-level result processing is handled by the manipulation_postprocessing plugin.
 """
 
 import json
-import logging
-from pathlib import Path
 from typing import Optional
 
-from rdflib import PROV, Namespace
+from pydantic import BaseModel, ConfigDict
+from rdflib import Namespace
 
 from robovast.common.variation.base_variation import ProvContribution, Variation
 from robovast_manipulation import MANIPULATION_NS_PREFIX, MANIPULATION_NS_URI
 
-logger = logging.getLogger(__name__)
-
 MANIPULATION = Namespace(MANIPULATION_NS_URI)
+
+_DEFAULT_PLANNERS = ["RRTConnect", "PTP", "KPIECE1"]
+
+
+class ManipulationVariationConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    planners: list[str] = _DEFAULT_PLANNERS
 
 
 class ManipulationVariation(Variation):
-    """Variation plugin that contributes manipulation-specific PROV-O nodes.
+    """Variation plugin for manipulation experiments.
 
-    Does not generate new configurations (``variation()`` is a pass-through).
-    Its sole purpose is to hook into the PROV generation pipeline via
-    ``prov_namespaces()`` and ``collect_prov_metadata()``.
+    Expands each input configuration into one config per planner ID, then
+    contributes manipulation-specific PROV-O scenario properties.
     """
 
+    CONFIG_CLASS = ManipulationVariationConfig
+
     def variation(self, in_configs):
-        """Pass configs through unchanged — this variation adds no new configs."""
-        return in_configs
+        results = []
+        for config in in_configs:
+            for planner in self.parameters.planners:
+                results.append(self.update_config(config, {"planner_id": planner}))
+        return results
 
     @classmethod
     def prov_namespaces(cls) -> dict:
-        """Declare the manipulation namespace prefix for the JSON-LD context."""
         return {MANIPULATION_NS_PREFIX: MANIPULATION_NS_URI}
 
     @classmethod
@@ -46,11 +53,10 @@ class ManipulationVariation(Variation):
         config_namespace,
         gen_activity_id: str,
         vast_id: str,
-        campaign_dir: Optional[Path] = None,
+        campaign_dir=None,
     ) -> Optional[ProvContribution]:
         config = config_entry.get("config", {})
 
-        # --- Config-level properties (merged onto ConcreteScenario node) ---
         scenario_properties: dict = {}
         if config.get("planner_id") is not None:
             scenario_properties[str(MANIPULATION["plannerId"])] = config["planner_id"]
@@ -67,55 +73,11 @@ class ManipulationVariation(Variation):
                 config["arm_joint_goal"]
             )
 
-        # --- Run-level nodes (one ManipulationExecution Activity per run) ---
-        graph_nodes = []
-
-        for run_entry in config_entry.get("test_results", []):
-            run_dir_rel = run_entry["dir"]  # e.g. "rrtconnect-1-1-1/1"
-            run_number = run_dir_rel.rsplit("/", 1)[-1]  # "1"
-
-            result: dict = {}
-            if campaign_dir is not None:
-                result_path = Path(campaign_dir) / run_dir_rel / "result.json"
-                try:
-                    with open(result_path, encoding="utf-8") as fh:
-                        result = json.load(fh)
-                except Exception as exc:
-                    logger.warning(
-                        "ManipulationVariation: could not read %s: %s",
-                        result_path,
-                        exc,
-                    )
-
-            test_exec_iri = str(campaign_namespace[run_dir_rel])
-            manip_exec_iri = str(
-                config_namespace[f"{run_number}/manipulation_execution"]
-            )
-
-            node: dict = {
-                "@id": manip_exec_iri,
-                "@type": [str(PROV["Activity"]), str(MANIPULATION["ManipulationExecution"])],
-                str(PROV["wasInformedBy"]): test_exec_iri,
-            }
-
-            for src_key, tgt_key in (
-                ("result_code",        str(MANIPULATION["resultCode"])),
-                ("planning_time_sec",  str(MANIPULATION["planningTimeSec"])),
-                ("execution_time_sec", str(MANIPULATION["executionTimeSec"])),
-                ("joint_space_error",  str(MANIPULATION["jointSpaceError"])),
-                ("final_joint_state",  str(MANIPULATION["finalJointState"])),
-            ):
-                val = result.get(src_key)
-                if val is not None:
-                    node[tgt_key] = val
-
-            graph_nodes.append(node)
-
-        if not scenario_properties and not graph_nodes:
+        if not scenario_properties:
             return None
 
         return ProvContribution(
-            graph_nodes=graph_nodes,
+            graph_nodes=[],
             scenario_properties=scenario_properties,
             run_used_iris=[],
         )


### PR DESCRIPTION
- New src/robovast_manipulation/ package
- fair_metadata: _build_iri_context() accepts extra_namespaces so plugins self-declare their prefixes via prov_namespaces()
- fair_metadata: passes campaign_dir= to collect_prov_metadata()
- base_variation: add campaign_dir=None to collect_prov_metadata
- pyproject.toml: entry point points to robovast_manipulation